### PR TITLE
Linux対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# アンナのお菓子な大冒険
+## Linuxでのビルド方法
+
+`~/work/` で作業するものとする。
+
+### Siv3Dのインストール
+
+[https://siv3d.github.io/ja-jp/download/ubuntu/](https://siv3d.github.io/ja-jp/download/ubuntu/)に従って以下のようにインストールする。
+
+```bash
+sudo apt update
+sudo apt install -y ninja-build libasound2-dev libavcodec-dev libavformat-dev libavutil-dev libboost-dev libcurl4-openssl-dev libgtk-3-dev libgif-dev libglu1-mesa-dev libharfbuzz-dev libmpg123-dev libopencv-dev libopus-dev libopusfile-dev libsoundtouch-dev libswresample-dev libtiff-dev libturbojpeg0-dev libvorbis-dev libwebp-dev libxft-dev uuid-dev xorg-dev
+cd ~/work
+git clone git@github.com:Siv3D/OpenSiv3D.git
+cd OpenSiv3D/Linux
+# ビルドのセットアップ
+mkdir build && cd build
+cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cd ..
+# ビルド&インスコ
+cmake --build build
+sudo cmake --install build
+```
+
+### リポジトリのセットアップ&リソースファイルのコピー
+
+```bash
+cd ~/work
+git clone git@github.com:ponzu840w/game-project.git
+cd game-project
+git checkout linux_build
+cp -r ~/work/OpenSiv3D/Linux/App/resources ~/work/game-project/アンナのお菓子な大冒険/App/
+cp -r ~/work/OpenSiv3D/Linux/App/resources ~/work/game-project/ステージエディタ改/App/
+```
+
+### ゲーム本体をビルド
+
+```bash
+cd ~/work/game-project/アンナのお菓子な大冒険
+# ビルドのセットアップ
+mkdir build && cd build
+cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cd ..
+# ビルド
+cmake –build build
+```
+
+### ゲーム本体を起動
+
+```bash
+cd ~/work/game-project/アンナのお菓子な大冒険/App
+./Annas_Candy_Adventrue
+```
+
+### ステージエディタをビルド
+```bash
+cd ~/work/game-project/ステージエディタ改
+# ビルドのセットアップ
+mkdir build && cd build
+cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cd ..
+# ビルド
+cmake –build build
+```
+
+### ステージエディタを起動
+
+```bash
+cd ~/work/game-project/ステージエディタ改/App
+./Stage_Editor_Kai
+```

--- a/アンナのお菓子な大冒険/AnimationSystem.h
+++ b/アンナのお菓子な大冒険/AnimationSystem.h
@@ -1,7 +1,5 @@
 ﻿#pragma once
 
-#include<Siv3D.hpp>
-
 class Movable {
 public:
 	Vec2 pos;

--- a/アンナのお菓子な大冒険/App/s1.json
+++ b/アンナのお菓子な大冒険/App/s1.json
@@ -1,7 +1,7 @@
 ﻿{
   "BackGround": [
-    "C:/Users/Torigoe/source/repos/game-project/アンナのお菓子な大冒険/App/backGround2.json",
-    "C:/Users/Torigoe/source/repos/game-project/アンナのお菓子な大冒険/App/backGround1.json"
+    "backGround2.json",
+    "backGround1.json"
   ],
   "Block": {
     "CakeGround": [

--- a/アンナのお菓子な大冒険/Attack.h
+++ b/アンナのお菓子な大冒険/Attack.h
@@ -1,5 +1,4 @@
 ﻿#pragma once
-#include<Siv3D.hpp>
 #include"Figure.hpp"
 
 class Attack {

--- a/アンナのお菓子な大冒険/CMakeLists.txt
+++ b/アンナのお菓子な大冒険/CMakeLists.txt
@@ -14,19 +14,13 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/App)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_executable(Annas_Candy_Adventrue
+  Block.cpp
+  Enemy.cpp
+  IMotionField.cpp
+  LastBoss.cpp
   Main.cpp
-  #../../Test/Siv3DTest.cpp
-  #../../Test/Siv3DTest_Array.cpp
-  #../../Test/Siv3DTest_BinaryReader.cpp
-  #../../Test/Siv3DTest_BinaryWriter.cpp
-  #../../Test/Siv3DTest_FileSystem.cpp
-  #../../Test/Siv3DTest_Image.cpp
-  #../../Test/Siv3DTest_Resource.cpp
-  #../../Test/Siv3DTest_Stopwatch.cpp
-  #../../Test/Siv3DTest_TextEncoding.cpp
-  #../../Test/Siv3DTest_TextReader.cpp
-  #../../Test/Siv3DTest_TextWriter.cpp
-  #../../Test/Siv3DTest_Timer.cpp
+  Movements.cpp
+  Player.cpp
   )
 
 target_precompile_headers(Annas_Candy_Adventrue PRIVATE stdafx.h)

--- a/アンナのお菓子な大冒険/CMakeLists.txt
+++ b/アンナのお菓子な大冒険/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.12)
+project(Annas_Candy_Adventrue CXX)
+
+if (NOT CMAKE_CONFIGURATION_TYPES AND 
+    NOT CMAKE_NO_BUILD_TYPE AND
+    NOT CMAKE_BUILD_TYPE AND
+    CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    message(STATUS "[!] Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/App)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+add_executable(Annas_Candy_Adventrue
+  Main.cpp
+  #../../Test/Siv3DTest.cpp
+  #../../Test/Siv3DTest_Array.cpp
+  #../../Test/Siv3DTest_BinaryReader.cpp
+  #../../Test/Siv3DTest_BinaryWriter.cpp
+  #../../Test/Siv3DTest_FileSystem.cpp
+  #../../Test/Siv3DTest_Image.cpp
+  #../../Test/Siv3DTest_Resource.cpp
+  #../../Test/Siv3DTest_Stopwatch.cpp
+  #../../Test/Siv3DTest_TextEncoding.cpp
+  #../../Test/Siv3DTest_TextReader.cpp
+  #../../Test/Siv3DTest_TextWriter.cpp
+  #../../Test/Siv3DTest_Timer.cpp
+  )
+
+target_precompile_headers(Annas_Candy_Adventrue PRIVATE stdafx.h)
+
+find_package(Siv3D)
+target_link_libraries(Annas_Candy_Adventrue PUBLIC Siv3D::Siv3D)
+
+target_compile_features(Annas_Candy_Adventrue PRIVATE cxx_std_20)
+

--- a/アンナのお菓子な大冒険/Figure.hpp
+++ b/アンナのお菓子な大冒険/Figure.hpp
@@ -182,13 +182,13 @@ public:
 	}
 
 	[[nodiscard]]
-	constexpr Figure movedBy(const Vec2& vec)const noexcept
+	Figure movedBy(const Vec2& vec)const noexcept
 	{
 		return Figure{ shape }.moveBy(vec);
 	}
 
 	[[nodiscard]]
-	constexpr Figure movedBy(double x, double y)const noexcept
+	Figure movedBy(double x, double y)const noexcept
 	{
 		return movedBy(Vec2{ x,y });
 	}
@@ -247,13 +247,13 @@ public:
 	}
 
 	[[nodiscard]]
-	constexpr Figure scaledAt(const Vec2& pos, double x, double y)const noexcept
+	Figure scaledAt(const Vec2& pos, double x, double y)const noexcept
 	{
 		return Figure{ shape }.scaleAt(pos, x, y);
 	}
 
 	[[nodiscard]]
-	constexpr Figure scaledAt(const Vec2& pos, double s)const noexcept
+	Figure scaledAt(const Vec2& pos, double s)const noexcept
 	{
 		return scaledAt(pos, s, s);
 	}
@@ -269,13 +269,13 @@ public:
 	}
 
 	[[nodiscard]]
-	constexpr Figure scaled(double x, double y)const noexcept
+	Figure scaled(double x, double y)const noexcept
 	{
 		return Figure{ shape }.scale(x, y);
 	}
 
 	[[nodiscard]]
-	constexpr Figure scaled(double s)const noexcept
+	Figure scaled(double s)const noexcept
 	{
 		return scaled(s, s);
 	}
@@ -310,13 +310,13 @@ public:
 	}
 
 	[[nodiscard]]
-	constexpr Figure rotatedAt(const Vec2& pos, double angle)const noexcept
+	Figure rotatedAt(const Vec2& pos, double angle)const noexcept
 	{
 		return Figure{ shape }.rotateAt(pos, angle);
 	}
 
 	[[nodiscard]]
-	constexpr Figure rotatedAt(double x, double y, double angle)const noexcept
+	Figure rotatedAt(double x, double y, double angle)const noexcept
 	{
 		return rotatedAt(Vec2{ x,y }, angle);
 	}
@@ -327,13 +327,13 @@ public:
 	}
 
 	[[nodiscard]]
-	constexpr Figure rotated(double angle)const noexcept
+	Figure rotated(double angle)const noexcept
 	{
 		return Figure{ shape }.rotate(angle);
 	}
 
 	[[nodiscard]]
-	constexpr LineString outline()const
+	LineString outline()const
 	{
 		switch (shape.index())
 		{

--- a/アンナのお菓子な大冒険/HitBox.h
+++ b/アンナのお菓子な大冒険/HitBox.h
@@ -1,5 +1,4 @@
 ﻿#pragma once
-#include<Siv3D.hpp>
 #include"Figure.hpp"
 #include"setting.h"
 

--- a/アンナのお菓子な大冒険/IMotionField.cpp
+++ b/アンナのお菓子な大冒険/IMotionField.cpp
@@ -1,4 +1,3 @@
-﻿#include "stdafx.h"
-#include "IMotionField.h"
+﻿#include "IMotionField.h"
 #include"AnimationSystem.h"
 #include"MotionLoader.h"

--- a/アンナのお菓子な大冒険/MainGameScene.h
+++ b/アンナのお菓子な大冒険/MainGameScene.h
@@ -348,7 +348,7 @@ public:
 		Rect{ Scene::Size() }.draw(ColorF{ 0,0.7 });
 		RoundRect{ Arg::center = Scene::Center(),1150,750,10 }.draw(ColorF{ Palette::Skyblue,0.7});
 		FontAsset(U"TitleFont")(U"ポーズ").drawAt(Scene::Center().x, 100);
-		FontAsset(U"TitleFont")(U"Space or W：ジャンプ\nA：左\nD：右\n：しゃがむ\nEnter：技を発動\nEnter長押し：突進(クッキーが10個貯まったら)\n").drawAt(50,Scene::Center());
+		FontAsset(U"TitleFont")(U"Space or W：ジャンプ\nA：左\nD：右\nS：しゃがむ\nEnter：技を発動\nEnter長押し：突進(クッキーが10個貯まったら)\n").drawAt(50,Scene::Center());
 		auto _=SimpleGUI::ButtonAt(U"ゲームに戻る", { Scene::Center().x,700 });
 	}
 

--- a/アンナのお菓子な大冒険/MainGameScene.h
+++ b/アンナのお菓子な大冒険/MainGameScene.h
@@ -348,7 +348,7 @@ public:
 		Rect{ Scene::Size() }.draw(ColorF{ 0,0.7 });
 		RoundRect{ Arg::center = Scene::Center(),1150,750,10 }.draw(ColorF{ Palette::Skyblue,0.7});
 		FontAsset(U"TitleFont")(U"ポーズ").drawAt(Scene::Center().x, 100);
-		FontAsset(U"TitleFont")(U"Space or W：ジャンプ\nA：左\nD：右\S：しゃがむ\nEnter：技を発動\nEnter長押し：突進(クッキーが10個貯まったら)\n").drawAt(50,Scene::Center());
+		FontAsset(U"TitleFont")(U"Space or W：ジャンプ\nA：左\nD：右\n：しゃがむ\nEnter：技を発動\nEnter長押し：突進(クッキーが10個貯まったら)\n").drawAt(50,Scene::Center());
 		auto _=SimpleGUI::ButtonAt(U"ゲームに戻る", { Scene::Center().x,700 });
 	}
 

--- a/アンナのお菓子な大冒険/Movements.cpp
+++ b/アンナのお菓子な大冒険/Movements.cpp
@@ -1,5 +1,4 @@
-﻿#include "stdafx.h"
-#include "Movements.h"
+﻿#include "Movements.h"
 #include"MotionLoader.h"
 
 

--- a/アンナのお菓子な大冒険/Stage.h
+++ b/アンナのお菓子な大冒険/Stage.h
@@ -2,8 +2,8 @@
 #include"Block.h"
 
 //何ブロックまで描画するか
-constexpr int range_right = 15;
-constexpr int range_left = 10;
+constexpr static int range_right = 15;
+constexpr static int range_left = 10;
 
 class Stage
 {

--- a/アンナのお菓子な大冒険/setting.h
+++ b/アンナのお菓子な大冒険/setting.h
@@ -1,19 +1,19 @@
 ﻿#pragma once
 //プレイヤーがどの高さまで来たら画面を切り替えるか
 //constexpr int change_hieght = -100;
-constexpr int change_hieght = -1000;//実質無効
+constexpr static int change_hieght = -1000;//実質無効
 
 
 //画面のどこにプレイヤーを描画するか
-constexpr int draw_x = 400;
-constexpr int draw_y = 570;
+constexpr static int draw_x = 400;
+constexpr static int draw_y = 570;
 
-constexpr int rect_size = 70;
+constexpr static int rect_size = 70;
 
 
 //重力加速度
-constexpr double gravity = 10;
+constexpr static double gravity = 10;
 
 //減速の割合
-constexpr double deceleration = 0.8;
+constexpr static double deceleration = 0.8;
 

--- a/ステージエディタ改/CMakeLists.txt
+++ b/ステージエディタ改/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.12)
+project(Stage_Editor_Kai CXX)
+
+if (NOT CMAKE_CONFIGURATION_TYPES AND 
+    NOT CMAKE_NO_BUILD_TYPE AND
+    NOT CMAKE_BUILD_TYPE AND
+    CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    message(STATUS "[!] Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/App)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+add_executable(Stage_Editor_Kai
+  Main.cpp
+  )
+
+target_precompile_headers(Stage_Editor_Kai PRIVATE stdafx.h)
+
+find_package(Siv3D)
+target_link_libraries(Stage_Editor_Kai PUBLIC Siv3D::Siv3D)
+
+target_compile_features(Stage_Editor_Kai PRIVATE cxx_std_20)

--- a/ステージエディタ改/Main.cpp
+++ b/ステージエディタ改/Main.cpp
@@ -1,5 +1,4 @@
-﻿# include <Siv3D.hpp>
-# include "table.h"
+﻿# include "table.h"
 
 
 bool check_range(Point pos, Point size) {

--- a/ステージエディタ改/Main.cpp
+++ b/ステージエディタ改/Main.cpp
@@ -244,7 +244,8 @@ void Main()
 				Optional<FilePath> path = Dialog::OpenFile({ FileFilter::JSON() });
 
 				if (path) {
-					backGrounds << BackGround{ path.value()};
+          const FilePath rpath = FileSystem::RelativePath(path.value());
+					backGrounds << BackGround{ rpath };
 				}
 
 

--- a/ステージエディタ改/table.h
+++ b/ステージエディタ改/table.h
@@ -1,5 +1,4 @@
 ﻿#pragma once
-# include <Siv3D.hpp>
 constexpr int32 rect_size = 70;
 
 //ここで画像の生成などをする


### PR DESCRIPTION
Linux版Siv3Dを使ってゲーム（&ステージエディタ）をビルドするために以下の変更をしました。

- ビルド構成ファイルの追加（CMakeLists.txt）
- コンパイラの違い（VisualStudioではMSVC、LinuxではGCC）に伴うソースコードの微修正
- ビルド手順を記したREADMEの作成

ついでに、特にLinuxとは関係ない以下の修正も行っています。

- ステージのjsonに含まれる、背景jsonのパスを相対パスに修正（s1.json及びエディタの修正）
- Escで表示される操作方法の脱字修正